### PR TITLE
Base attrs are now assigned to instance variable, fixes RateLimit

### DIFF
--- a/lib/uber/base.rb
+++ b/lib/uber/base.rb
@@ -8,11 +8,11 @@ module Uber
     # @param attrs [Hash]
     # @return [Uber::Base]
     def initialize(attrs = {})
-      if !(attrs.nil? || attrs == "")
-        attrs.each do |key, value|
-          if respond_to?(:"#{key}=")
-            send(:"#{key}=", value)
-          end
+      return if attrs.nil? || attrs.empty?
+      @attrs = attrs
+      attrs.each do |key, value|
+        if respond_to?(:"#{key}=")
+          send(:"#{key}=", value)
         end
       end
     end

--- a/lib/uber/rate_limit.rb
+++ b/lib/uber/rate_limit.rb
@@ -15,12 +15,12 @@ module Uber
     # @return [Time]
     def reset_at
       reset = @attrs['x-rate-limit-reset']
-      Time.at(reset.to_i) if reset
+      ::Time.at(reset.to_i) if reset
     end
 
     # @return [Integer]
     def reset_in
-      [(reset_at - Time.now).ceil, 0].max if reset_at
+      [(reset_at - ::Time.now).ceil, 0].max if reset_at
     end
   end
 end

--- a/spec/lib/rate_limit_spec.rb
+++ b/spec/lib/rate_limit_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+require "uber"
+
+describe Uber::RateLimit do
+  let!(:now) { Time.at(1449638388) }
+  let(:rate_limit) { 
+    Uber::RateLimit.new({
+      'x-rate-limit-limit' => 500,
+      'x-rate-limit-remaining' => 499,
+      'x-rate-limit-reset' => now.to_i
+    })
+  }
+
+  it 'should return rate limit values' do
+    expect(rate_limit.limit).to eq 500
+    expect(rate_limit.remaining).to eq 499
+  end
+
+  it 'should provide reset time' do
+    allow(Time).to receive(:now) { now - 100 }
+    expect(rate_limit.reset_at).to eq now
+    expect(rate_limit.reset_in).to eq 100
+  end
+end
+
+


### PR DESCRIPTION
Hello,

Thanks for the awesome gem. Very useful. 

I noticed that the attrs hash wasn't assigned in base.rb and the same was being used in RateLimit. I suspect this would fail and I have updated to code with tests to validate the same.

Can you please review the changes ? 
