### PR TITLE
Changed api/activities.rb from v1.1 to v1.2 and added :start_city att…

### DIFF
--- a/lib/uber/api/activities.rb
+++ b/lib/uber/api/activities.rb
@@ -7,7 +7,7 @@ module Uber
     module Activities
       def history(*args)
         arguments = Uber::Arguments.new(args)
-        perform_with_object(:get, "/v1.1/history", arguments.options, Activity)
+        perform_with_object(:get, "/v1.2/history", arguments.options, Activity)
       end
     end
   end

--- a/lib/uber/models/activity.rb
+++ b/lib/uber/models/activity.rb
@@ -8,7 +8,7 @@ module Uber
   end
 
   class History < Base
-    attr_accessor :uuid, :request_time, :product_id, :status, :distance, :start_time, :end_time
+    attr_accessor :uuid, :request_time, :product_id, :status, :distance, :start_time, :end_time, :start_city
 
     def request_time=(value)
       @request_time = ::Time.at(value)


### PR DESCRIPTION
Hi,

Thank you for creating this gem, it is very useful!  

I made a small update that changed api/activities.rb from v1.1 to v1.2 and added :start_city attr_accessor to models/activity.rb.

History v1.2 allows api to return city info that ride originated in, v1.1 does not make this data available.

:start_city attr_accessor allows user to call on start_city.
