### PR TITLE
added more available options in Product

### DIFF
--- a/lib/uber/models/product.rb
+++ b/lib/uber/models/product.rb
@@ -2,5 +2,9 @@ module Uber
   class Product < Base
     attr_accessor :product_id, :description, :display_name, :capacity, :image,
                   :cash_enabled, :shared, :price_details
+
+    [:cash_enabled, :shared].each do |m|
+      define_method("#{m}?") { instance_variable_get("@#{m}") }
+    end
   end
 end

--- a/lib/uber/models/product.rb
+++ b/lib/uber/models/product.rb
@@ -1,5 +1,6 @@
 module Uber
   class Product < Base
-    attr_accessor :product_id, :description, :display_name, :capacity, :image
+    attr_accessor :product_id, :description, :display_name, :capacity, :image,
+                  :cash_enabled, :shared, :price_details
   end
 end

--- a/spec/lib/api/products_spec.rb
+++ b/spec/lib/api/products_spec.rb
@@ -124,6 +124,8 @@ describe Uber::API::Products do
         expect(products[0].price_details.class).to be Hash
         expect(products[0].shared).to be true
         expect(products[0].cash_enabled).to be true
+        expect(products[0].shared?).to be true
+        expect(products[0].cash_enabled?).to be true
 
         expect(products[1].capacity).to eql 6
         expect(products[1].description).to eql "low-cost rides for large groups"
@@ -160,6 +162,8 @@ describe Uber::API::Products do
         expect(products[4].price_details).to be nil
         expect(products[4].shared).to be false
         expect(products[4].cash_enabled).to be false
+        expect(products[4].shared?).to be false
+        expect(products[4].cash_enabled?).to be false
       end
     end
   end

--- a/spec/lib/api/products_spec.rb
+++ b/spec/lib/api/products_spec.rb
@@ -31,7 +31,9 @@ describe Uber::API::Products do
                                 },
                                 "image" => "http://d1a3f4spazzrp4.cloudfront.net/car.jpg",
                                 "display_name" => "uberX",
-                                "product_id" => "a1111c8c-c720-46c3-8534-2fcdd730040d"
+                                "product_id" => "a1111c8c-c720-46c3-8534-2fcdd730040d",
+                                "shared" => true,
+                                "cash_enabled" => true
                               },
                               {
                                 "capacity" => 6,
@@ -53,7 +55,9 @@ describe Uber::API::Products do
                                 },
                                 "image" => "http://d1a3f4spazzrp4.cloudfront.net/car.jpg",
                                 "display_name" => "uberXL",
-                                "product_id" => "821415d8-3bd5-4e27-9604-194e4359a449"
+                                "product_id" => "821415d8-3bd5-4e27-9604-194e4359a449",
+                                "shared" => true,
+                                "cash_enabled" => true
                               },
                               {
                                 "capacity" => 4,
@@ -70,7 +74,9 @@ describe Uber::API::Products do
                                 },
                                 "image" => "http://d1a3f4spazzrp4.cloudfront.net/car.jpg",
                                 "display_name" => "UberBLACK",
-                                "product_id" => "d4abaae7-f4d6-4152-91cc-77523e8165a4"
+                                "product_id" => "d4abaae7-f4d6-4152-91cc-77523e8165a4",
+                                "shared" => false,
+                                "cash_enabled" => true
                               },
                               {
                                 "capacity" => 6,
@@ -87,7 +93,9 @@ describe Uber::API::Products do
                                 },
                                 "image" => "http://d1a3f4spazzrp4.cloudfront.net/car.jpg",
                                 "display_name" => "UberSUV",
-                                "product_id" => "8920cb5e-51a4-4fa4-acdf-dd86c5e18ae0"
+                                "product_id" => "8920cb5e-51a4-4fa4-acdf-dd86c5e18ae0",
+                                "shared" => true,
+                                "cash_enabled" => false
                               },
                               {
                                 "capacity" => 4,
@@ -95,7 +103,9 @@ describe Uber::API::Products do
                                 "price_details" => nil,
                                 "image" => "http://d1a3f4spazzrp4.cloudfront.net/car.jpg",
                                 "display_name" => "uberTAXI",
-                                "product_id" => "3ab64887-4842-4c8e-9780-ccecd3a0391d"
+                                "product_id" => "3ab64887-4842-4c8e-9780-ccecd3a0391d",
+                                "shared" => false,
+                                "cash_enabled" => false
                               }
                             ]
                           }
@@ -111,30 +121,45 @@ describe Uber::API::Products do
         expect(products[0].display_name).to eql "uberX"
         expect(products[0].product_id).to eql "a1111c8c-c720-46c3-8534-2fcdd730040d"
         expect(products[0].image).to eql "http://d1a3f4spazzrp4.cloudfront.net/car.jpg"
+        expect(products[0].price_details.class).to be Hash
+        expect(products[0].shared).to be true
+        expect(products[0].cash_enabled).to be true
 
         expect(products[1].capacity).to eql 6
         expect(products[1].description).to eql "low-cost rides for large groups"
         expect(products[1].display_name).to eql "uberXL"
         expect(products[1].product_id).to eql "821415d8-3bd5-4e27-9604-194e4359a449"
         expect(products[1].image).to eql "http://d1a3f4spazzrp4.cloudfront.net/car.jpg"
+        expect(products[1].price_details.class).to be Hash
+        expect(products[1].shared).to be true
+        expect(products[1].cash_enabled).to be true
 
         expect(products[2].capacity).to eql 4
         expect(products[2].description).to eql "The original Uber"
         expect(products[2].display_name).to eql "UberBLACK"
         expect(products[2].product_id).to eql "d4abaae7-f4d6-4152-91cc-77523e8165a4"
         expect(products[2].image).to eql "http://d1a3f4spazzrp4.cloudfront.net/car.jpg"
+        expect(products[2].price_details.class).to be Hash
+        expect(products[2].shared).to be false
+        expect(products[2].cash_enabled).to be true
 
         expect(products[3].capacity).to eql 6
         expect(products[3].description).to eql "Room for everyone"
         expect(products[3].display_name).to eql "UberSUV"
         expect(products[3].product_id).to eql "8920cb5e-51a4-4fa4-acdf-dd86c5e18ae0"
         expect(products[3].image).to eql "http://d1a3f4spazzrp4.cloudfront.net/car.jpg"
+        expect(products[3].price_details.class).to be Hash
+        expect(products[3].shared).to be true
+        expect(products[3].cash_enabled).to be false
 
         expect(products[4].capacity).to eql 4
         expect(products[4].description).to eql "Taxi without the hassle"
         expect(products[4].display_name).to eql "uberTAXI"
         expect(products[4].product_id).to eql "3ab64887-4842-4c8e-9780-ccecd3a0391d"
         expect(products[4].image).to eql "http://d1a3f4spazzrp4.cloudfront.net/car.jpg"
+        expect(products[4].price_details).to be nil
+        expect(products[4].shared).to be false
+        expect(products[4].cash_enabled).to be false
       end
     end
   end


### PR DESCRIPTION
This extends `Product` model by adding:
- cash_enabled
- shared
- pricing_details

and equivalent `cash_enabled?`, `shared?` methods.
