### PR TITLE
Enable debug log for client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ end
 # More info here https://developer.uber.com/docs/sandbox#section-product-types
 ```
 
+## Debug mode
+Add `config.debug = true` to log HTTP request-response headers while making API requests.
+
 ## Usage
 
 ### Request Products

--- a/lib/uber/client.rb
+++ b/lib/uber/client.rb
@@ -12,6 +12,7 @@ module Uber
     attr_accessor :server_token, :client_id, :client_secret
     attr_accessor :bearer_token
     attr_accessor :sandbox
+    attr_accessor :debug
 
     attr_writer :connection_options, :middleware
     ENDPOINT = 'https://api.uber.com'
@@ -59,6 +60,7 @@ module Uber
         faraday.request :url_encoded
         # Parse JSON response bodies
         faraday.response :parse_json
+        faraday.response :logger if self.debug
         # Use instrumentation if available
         faraday.use :instrumentation if defined?(FaradayMiddleware::Instrumentation)
         # Set default HTTP adapter

--- a/spec/lib/api/requests_spec.rb
+++ b/spec/lib/api/requests_spec.rb
@@ -335,4 +335,22 @@ describe Uber::API::Requests do
       expect(request.class).to eql Uber::Request
     end
   end
+
+  describe 'client' do
+    let!(:client) { setup_client }
+    let!(:debug_client) { setup_client(debug: true) }
+
+    it 'should not have logger middleware when debug option is not passed' do
+      client.send(:connection).builder.handlers.should_not include Faraday::Response::Logger
+    end
+
+    it 'should have logger middleware when debug option is passed' do
+      debug_client.send(:connection).builder.handlers.should include Faraday::Response::Logger
+    end
+
+    it 'should include Uber::Response::ParseJson middleware in both clients' do
+      client.send(:connection).builder.handlers.should include Uber::Response::ParseJson
+      debug_client.send(:connection).builder.handlers.should include Uber::Response::ParseJson
+    end
+  end
 end

--- a/spec/support/client_helpers.rb
+++ b/spec/support/client_helpers.rb
@@ -4,7 +4,8 @@ module ClientHelpers
   def setup_client(opts = {})
     Uber::Client.new do |c|
       c.bearer_token = 'UBER_BEARER_TOKEN'
-      c.sandbox = opts[:sandbox]
+      c.sandbox      = opts[:sandbox]
+      c.debug        = opts[:debug]
     end
   end
 


### PR DESCRIPTION
This will expose the `config.debug` to enable HTTP request-response logging while making api requests. This helps dev in finding intrinsic details about the request made. // cc @sishen 

> I, [2016-09-04T16:13:52.415581 #17056]  INFO -- : get https://sandbox-api.uber.com/v1/me
> D, [2016-09-04T16:13:52.415786 #17056] DEBUG -- request: Accept: "_/_"
> User-Agent: "Uber Ruby Gem 0.6.0"
> Content-Type: "application/json; charset=UTF-8"
> Authorization: "Bearer my-token"
> I, [2016-09-04T16:13:54.509103 #17056]  INFO -- Status: 200
> D, [2016-09-04T16:13:54.509195 #17056] DEBUG -- response: server: "nginx"
> date: "Sun, 04 Sep 2016 10:43:49 GMT"
> content-type: "application/json"
> content-length: "325"
> connection: "close"
> content-language: "en"
> x-rate-limit-limit: "2000"
> x-rate-limit-remaining: "1994"
> x-rate-limit-reset: "1472986800"
> x-uber-app: "uberex-sandbox, migrator-uberex-sandbox-optimus"
> strict-transport-security: "max-age=0"
> x-content-type-options: "nosniff"
> x-xss-protection: "1; mode=block"
