### PR TITLE
RequestTimeout error class didn't exist

### DIFF
--- a/lib/uber/error.rb
+++ b/lib/uber/error.rb
@@ -78,6 +78,9 @@ module Uber
 
     class ClientError < self; end
 
+    # Raised when Uber requests are timed-out
+    class RequestTimeout < ClientError; end
+
     class ConfigurationError < ::ArgumentError; end
 
     # Raised when Uber returns the HTTP status code 400


### PR DESCRIPTION
This broke [here](https://github.com/sishen/uber-ruby/blob/master/lib/uber/client.rb#L136) 
