### PR TITLE
Handle errors

### DIFF
--- a/lib/uber/client.rb
+++ b/lib/uber/client.rb
@@ -138,10 +138,7 @@ module Uber
     rescue Faraday::Error::TimeoutError, Timeout::Error => error
       raise(Uber::Error::RequestTimeout.new(error))
     rescue Faraday::Error::ClientError, Faraday::Error::ResourceNotFound, Faraday::Error::ConnectionFailed, JSON::ParserError => error
-      # TODO: check if I can just handle Faraday::Error
-      #debugger
       raise Uber::Error.from_error error
-      # fail(Uber::Error.new(error))
     end
 
     def request_headers(method, path, params = {}, signature_params = params)

--- a/lib/uber/error.rb
+++ b/lib/uber/error.rb
@@ -30,7 +30,8 @@ module Uber
 
       def from_error(error)
         message, code = parse_error((JSON.parse(error.response[:body]) rescue nil), error.response[:status])
-        new(message, error.response[:headers], code)
+        error_base_klass = errors[code] || self
+        error_base_klass.new(message, error.response[:headers], code)
       end
 
       # @return [Hash]

--- a/lib/uber/error.rb
+++ b/lib/uber/error.rb
@@ -28,6 +28,11 @@ module Uber
         new(message, response.response_headers, code)
       end
 
+      def from_error(error)
+        message, code = parse_error((JSON.parse(error.response[:body]) rescue nil), error.response[:status])
+        new(message, error.response[:headers], code)
+      end
+
       # @return [Hash]
       def errors
         @errors ||= {
@@ -44,11 +49,13 @@ module Uber
 
     private
 
-      def parse_error(body)
+      def parse_error(body, status_code=nil)
         if body.nil?
           ['', nil]
         elsif body[:error]
           [body[:error], nil]
+        elsif body[:message] || body['message']
+          [body[:message] || body['message'], status_code]
         elsif body[:errors]
           extract_message_from_errors(body)
         end

--- a/lib/uber/models/estimate.rb
+++ b/lib/uber/models/estimate.rb
@@ -18,7 +18,7 @@ module Uber
   end
 
   class Price < Base
-    attr_accessor :surge_confirmation_href, :surge_confirmation_id, :high_estimate, :low_estimate, :minimum, :surge_multiplier, :display, :currency_code
+    attr_accessor :surge_confirmation_href, :surge_confirmation_id, :high_estimate, :low_estimate, :minimum, :surge_multiplier, :display, :currency_code, :fare_breakdown
   end
 
   class Trip < Base


### PR DESCRIPTION
_Do not merge this yet_
@sishen : I'm using raise_error middleware of Faraday and passing the message to `Uber::Error.from_error` which raises exception based on status code.
Though, this is not a good solution for [`Request` errors](https://developer.uber.com/docs/rides/api/v1-requests#http-error-codes), since it was being handled by `RequestError` earlier. Should I re-use this for `Request` and continue to use `Uber::Error` for others? Suggestions?
