### PR TITLE
add accessors for pickup, destination to Request model

### DIFF
--- a/lib/uber/models/request.rb
+++ b/lib/uber/models/request.rb
@@ -1,6 +1,6 @@
 module Uber
   class Request < Base
-    attr_accessor :request_id, :status, :vehicle, :driver, :location, :eta, :surge_multiplier, :meta, :errors
+    attr_accessor :request_id, :status, :vehicle, :driver, :location, :pickup, :destination, :eta, :surge_multiplier, :meta, :errors
 
     def driver=(value)
       @driver = value.nil? ? nil : Driver.new(value)
@@ -12,6 +12,14 @@ module Uber
 
     def location=(value)
       @location = value.nil? ? nil : Location.new(value)
+    end
+
+    def pickup=(value)
+      @pickup = value.nil? ? nil : Location.new(value)
+    end
+
+    def destination=(value)
+      @destination = value.nil? ? nil : Location.new(value)
     end
 
     def errors=(values)

--- a/lib/uber/models/request.rb
+++ b/lib/uber/models/request.rb
@@ -58,6 +58,6 @@ module Uber
   end
 
   class Location < Base
-    attr_accessor :latitude, :longitude, :bearing
+    attr_accessor :latitude, :longitude, :bearing, :eta
   end
 end

--- a/spec/lib/api/requests_spec.rb
+++ b/spec/lib/api/requests_spec.rb
@@ -248,6 +248,14 @@ describe Uber::API::Requests do
                             "longitude" => -122.418143,
                             "bearing" => 33
                           },
+                          "pickup" => {
+                            "latitude" => 0.0,
+                            "longitude" => 0.5
+                          },
+                          "destination" => {
+                            "latitude" => 0.0,
+                            "longitude" => 0.6
+                          },
                           "vehicle" => {
                             "make" => "Bugatti",
                             "model" => "Veyron",
@@ -275,6 +283,12 @@ describe Uber::API::Requests do
       expect(request.location.latitude).to eql 37.776033
       expect(request.location.longitude).to eql -122.418143
       expect(request.location.bearing).to eql 33
+
+      expect(request.pickup.latitude).to eql 0.0
+      expect(request.pickup.longitude).to eql 0.5
+
+      expect(request.destination.latitude).to eql 0.0
+      expect(request.destination.longitude).to eql 0.6
 
       expect(request.vehicle.make).to eql 'Bugatti'
       expect(request.vehicle.model).to eql 'Veyron'

--- a/spec/lib/api/requests_spec.rb
+++ b/spec/lib/api/requests_spec.rb
@@ -250,11 +250,13 @@ describe Uber::API::Requests do
                           },
                           "pickup" => {
                             "latitude" => 0.0,
-                            "longitude" => 0.5
+                            "longitude" => 0.5,
+                            "eta" => 5
                           },
                           "destination" => {
                             "latitude" => 0.0,
-                            "longitude" => 0.6
+                            "longitude" => 0.6,
+                            "eta" => 19
                           },
                           "vehicle" => {
                             "make" => "Bugatti",
@@ -286,9 +288,11 @@ describe Uber::API::Requests do
 
       expect(request.pickup.latitude).to eql 0.0
       expect(request.pickup.longitude).to eql 0.5
+      expect(request.pickup.eta).to eql 5
 
       expect(request.destination.latitude).to eql 0.0
       expect(request.destination.longitude).to eql 0.6
+      expect(request.destination.eta).to eql 19
 
       expect(request.vehicle.make).to eql 'Bugatti'
       expect(request.vehicle.model).to eql 'Veyron'


### PR DESCRIPTION
- The pickup and destination locations are included in the trip details
  response. This adds accessors to easily access them from code after
  retrieving them from the trip details endpoint.