### PR TITLE
Upgrade to v1.2/me endpoint

### DIFF
--- a/lib/uber/api/me.rb
+++ b/lib/uber/api/me.rb
@@ -7,7 +7,7 @@ module Uber
     module Me
       def me(*args)
         arguments = Uber::Arguments.new(args)
-        perform_with_object(:get, "/v1/me", arguments.options, User)
+        perform_with_object(:get, "/v1.2/me", arguments.options, User)
       end
     end
   end

--- a/lib/uber/models/user.rb
+++ b/lib/uber/models/user.rb
@@ -1,6 +1,6 @@
 module Uber
   class User < Base
-    attr_accessor :first_name, :last_name, :email, :picture, :promo_code, :mobile_verified, :uuid
+    attr_accessor :first_name, :last_name, :email, :picture, :promo_code, :mobile_verified, :uuid, :rider_id
 
     def mobile_verified?
       !!self.mobile_verified

--- a/spec/lib/api/me_spec.rb
+++ b/spec/lib/api/me_spec.rb
@@ -4,28 +4,33 @@ require "uber"
 describe Uber::API::Me do
   let!(:client) { setup_client }
 
+  let(:response_body) do
+    # From: https://developer.uber.com/docs/riders/references/api/v1.2/me-get
+    {
+      picture: "https://d1w2poirtb3as9.cloudfront.net/f3be498cb0bbf570aa3d.jpeg",
+      first_name: "Uber",
+      last_name: "Developer",
+      uuid: "f4a416e3-6016-4623-8ec9-d5ee105a6e27",
+      rider_id: "8OlTlUG1TyeAQf1JiBZZdkKxuSSOUwu2IkO0Hf9d2HV52Pm25A0NvsbmbnZr85tLVi-s8CckpBK8Eq0Nke4X-no3AcSHfeVh6J5O6LiQt5LsBZDSi4qyVUdSLeYDnTtirw==",
+      email: "uberdevelopers@gmail.com",
+      mobile_verified: true,
+      promo_code: "uberd340ue"
+    }
+  end
+
   before do
-    stub_uber_request(:get, "v1/me",
-                      # From: https://developer.uber.com/v1/endpoints/#user-profile
-                      {
-                        "first_name" => "Uber",
-                        "last_name" => "Developer",
-                        "email" => "developer@uber.com",
-                        "picture" => "https://cloudfront.net/deadbeef.jpg",
-                        "promo_code" => "teypo",
-                        "uuid" => "91d81273-45c2-4b57-8124-d0165f8240c0",
-                        "mobile_verified" => true
-                      })
+    stub_uber_request(:get, "v1.2/me", response_body)
   end
 
   it "should return the user profile" do
     profile = client.me
-    expect(profile.first_name).to eql "Uber"
-    expect(profile.last_name).to eql "Developer"
-    expect(profile.email).to eql "developer@uber.com"
-    expect(profile.picture).to eql "https://cloudfront.net/deadbeef.jpg"
-    expect(profile.promo_code).to eql "teypo"
-    expect(profile.uuid).to eql "91d81273-45c2-4b57-8124-d0165f8240c0"
+    expect(profile.first_name).to eq response_body[:first_name]
+    expect(profile.last_name).to eq response_body[:last_name]
+    expect(profile.email).to eq response_body[:email]
+    expect(profile.picture).to eq response_body[:picture]
+    expect(profile.promo_code).to eq response_body[:promo_code]
+    expect(profile.uuid).to eq response_body[:uuid]
+    expect(profile.rider_id).to eq response_body[:rider_id]
     expect(profile.mobile_verified).to be true
     expect(profile.mobile_verified?).to be true
   end


### PR DESCRIPTION
The response from `v1/me` and `v1.2/me` looks the same however the returned object doesn't have `rider_id` attribute. This PR adds `rider_id` attribute to User model
